### PR TITLE
Poprawki odnośnie wydajności oraz dodano generowanie PDF'ów

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# useage: pip3 install -r requirements.txt --user
+
+fpdf

--- a/script1.0.py
+++ b/script1.0.py
@@ -4,15 +4,25 @@ import os
 from urllib import request
 from argparse import ArgumentParser
 from sys import argv
+from logging import Logger, INFO
+
+log = Logger(__file__, level=INFO)
+
+# CONST
+BOOL_PARAM = dict(nargs='?', type=bool, const=True, default=False)
 
 arg_engine = ArgumentParser()
-arg_engine.add_argument('-b','--book-id', type=int, target='book_id', required=True, help='id of book to download')
-arg_engine.add_argument('-p','--pages', type=int, target='pages', required=True, help='amount of pages to download')
+arg_engine.add_argument('-b', '--book-id', type=int, dest='book_id', required=True, help='id of book to download')
+arg_engine.add_argument('-p', '--pages', type=int, dest='pages', required=True, help='amount of pages to download')
+arg_engine.add_argument('-d', '--datadir', type=str, dest='datadir', default='pages', required=False, help='specifies directory where pages will be scrapped')
+arg_engine.add_argument('-f', '--force', dest='force', help='if given, overrides files in directory', **BOOL_PARAM)
 args = arg_engine.parse_args(list(argv[1:]))
 
 # ----------------------------------
-bookId = args.book_id # ID książki
-pages = args.pages # liczba stron książki
+bookId = args.book_id # book ID
+pages = args.pages # book page ccount
+datadir = args.datadir # path to directory with downloads
+override_files = args.force # override existing directory
 # ----------------------------------
 
 opener = request.build_opener()
@@ -21,7 +31,16 @@ request.install_opener(opener)
 pageText = "pages/page"
 fileExtension = ".PNG"
 
-os.mkdir("pages")
+if os.path.exists(datadir):
+	if not override_files:
+		log.warning('directory already exist, change path or remove existing one')
+		exit(-1)
+else:
+	try:
+		os.mkdir(datadir)
+	except Exception as e:
+		log.error(f'exception occured while creating directory: {e}')
+
 for i in range (1,int(pages) + 1):
   print("https://flipbook.apps.gwo.pl/book/getImage/bookId:" + str(bookId) + "/pageNo:" + str(i))
   filename = pageText + str(i) + fileExtension

--- a/script1.0.py
+++ b/script1.0.py
@@ -5,8 +5,11 @@ from urllib import request
 from argparse import ArgumentParser
 from sys import argv
 from pathlib import Path
+from logging import INFO, getLogger, basicConfig
 
-log = Logger(__file__, level=INFO)
+# Logger configuration
+basicConfig(level=INFO, format='[%(levelname)s][%(asctime)s] %(message)s')
+log = getLogger(Path(__file__).name)
 
 # CONST
 BASE_URL = "https://flipbook.apps.gwo.pl/book/getImage/bookId:"

--- a/script1.0.py
+++ b/script1.0.py
@@ -1,20 +1,30 @@
-import urllib.request
+#!/usr/bin/python3
+
 import os
-opener=urllib.request.build_opener()
-opener.addheaders=[('User-Agent','Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1941.0 Safari/537.36')]
-urllib.request.install_opener(opener)
-pageText = "pages/page"
-fileExtension = ".PNG"
+from urllib import request
+from argparse import ArgumentParser
+from sys import argv
+
+arg_engine = ArgumentParser()
+arg_engine.add_argument('-b','--book-id', type=int, target='book_id', required=True, help='id of book to download')
+arg_engine.add_argument('-p','--pages', type=int, target='pages', required=True, help='amount of pages to download')
+args = arg_engine.parse_args(list(argv[1:]))
 
 # ----------------------------------
-bookId = 2350 # ID książki
-pages = 5 # liczba stron książki
+bookId = args.book_id # ID książki
+pages = args.pages # liczba stron książki
 # ----------------------------------
+
+opener = request.build_opener()
+opener.addheaders=[('User-Agent','Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1941.0 Safari/537.36')]
+request.install_opener(opener)
+pageText = "pages/page"
+fileExtension = ".PNG"
 
 os.mkdir("pages")
 for i in range (1,int(pages) + 1):
   print("https://flipbook.apps.gwo.pl/book/getImage/bookId:" + str(bookId) + "/pageNo:" + str(i))
   filename = pageText + str(i) + fileExtension
   image_url = "https://flipbook.apps.gwo.pl/book/getImage/bookId:" + str(bookId) + "/pageNo:" + str(i)
-  urllib.request.urlretrieve(image_url, filename)
+  request.urlretrieve(image_url, filename)
   print("   " + filename)

--- a/script1.0.py
+++ b/script1.0.py
@@ -1,16 +1,18 @@
 #!/usr/bin/python3
 
 from argparse import ArgumentParser
+from concurrent.futures import ThreadPoolExecutor
 from logging import INFO, basicConfig, getLogger
+from urllib.request import Request, urlopen
 from pathlib import Path
 from sys import argv
-from urllib.request import Request, urlopen
 
 # Logger configuration
 basicConfig(level=INFO, format='[%(levelname)s][%(asctime)s] %(message)s')
 log = getLogger(Path(__file__).name)
 
 # CONST
+PAGE_OFFSET = 1 # first book page on website is one
 BASE_URL = "https://flipbook.apps.gwo.pl/book/getImage/bookId:"
 HEADERS = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1941.0 Safari/537.36'}
 BOOL_PARAM = dict(nargs='?', type=bool, const=True, default=False)
@@ -22,15 +24,18 @@ arg_engine.add_argument('-b', '--book-id', type=int, dest='book_id', required=Tr
 arg_engine.add_argument('-p', '--pages', type=int, dest='pages', required=True, help='amount of pages to download')
 arg_engine.add_argument('-d', '--datadir', type=str, dest='datadir', default='pages', required=False, help='specifies directory where pages will be scrapped')
 arg_engine.add_argument('-k', '--prefix', type=str, dest='prefix', default='page_', required=False, help='specifies prefix before every page, concatenated with number and format')
+arg_engine.add_argument('-j', '--jobs', type=int, dest='jobs', default=1, help='specifies amount of jobs that will be used for downloading')
 arg_engine.add_argument('-f', '--force', dest='force', help='if given, overrides files in directory', **BOOL_PARAM)
 args = arg_engine.parse_args(list(argv[1:]))
 
 # ----------------------------------
 bookId = args.book_id # book ID
-pages = args.pages # book page ccount
+pages_cnt = args.pages # book page ccount
+max_page = pages_cnt + PAGE_OFFSET
 datadir = Path(args.datadir) # path to directory with downloads
 override_files = args.force # override existing directory
 prefix = args.prefix
+workers = args.jobs
 # ----------------------------------
 
 def retrive_image(url, path):
@@ -54,6 +59,9 @@ def handle_page(page_num):
 	log.info(f'downloading page number {page_num} from: {url}')
 	retrive_image(url, path)
 
+def handle_range(start, stop):
+	for page_num in range(start, stop):
+		handle_page(page_num)
 
 # Path handling
 if datadir.exists():
@@ -66,5 +74,13 @@ else:
 	except Exception as e:
 		log.error(f'exception occured while creating directory: {e}')
 
-for i in range (1,int(pages) + 1):
-	handle_page(i)
+page_stop_range = max_page + 1
+pages_per_worker = int(page_stop_range / workers)
+with ThreadPoolExecutor(max_workers=workers) as executor:
+	futures = []
+	for i in range(PAGE_OFFSET, page_stop_range, pages_per_worker):
+		futures.append(executor.submit(handle_range, i, min(max_page, i + pages_per_worker)))
+
+	for future in futures:
+		exc = future.exception()
+		assert exc is None, f'job finished with exception: {exc}'

--- a/script1.0.py
+++ b/script1.0.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 
-import os
+
 from urllib import request
 from argparse import ArgumentParser
 from sys import argv
-from logging import Logger, INFO
+from pathlib import Path
 
 log = Logger(__file__, level=INFO)
 
@@ -21,7 +21,7 @@ args = arg_engine.parse_args(list(argv[1:]))
 # ----------------------------------
 bookId = args.book_id # book ID
 pages = args.pages # book page ccount
-datadir = args.datadir # path to directory with downloads
+datadir = Path(args.datadir) # path to directory with downloads
 override_files = args.force # override existing directory
 # ----------------------------------
 
@@ -31,13 +31,14 @@ request.install_opener(opener)
 pageText = "pages/page"
 fileExtension = ".PNG"
 
-if os.path.exists(datadir):
+# Path handling
+if datadir.exists():
 	if not override_files:
 		log.warning('directory already exist, change path or remove existing one')
 		exit(-1)
 else:
 	try:
-		os.mkdir(datadir)
+		datadir.mkdir()
 	except Exception as e:
 		log.error(f'exception occured while creating directory: {e}')
 

--- a/script1.0.py
+++ b/script1.0.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-
+from requests import get
 from urllib import request
 from argparse import ArgumentParser
 from sys import argv
@@ -9,12 +9,17 @@ from pathlib import Path
 log = Logger(__file__, level=INFO)
 
 # CONST
+BASE_URL = "https://flipbook.apps.gwo.pl/book/getImage/bookId:"
+HEADERS = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1941.0 Safari/537.36'}
 BOOL_PARAM = dict(nargs='?', type=bool, const=True, default=False)
+IMAGE_EXT = 'png'
 
+# ARGUMENTS
 arg_engine = ArgumentParser()
 arg_engine.add_argument('-b', '--book-id', type=int, dest='book_id', required=True, help='id of book to download')
 arg_engine.add_argument('-p', '--pages', type=int, dest='pages', required=True, help='amount of pages to download')
 arg_engine.add_argument('-d', '--datadir', type=str, dest='datadir', default='pages', required=False, help='specifies directory where pages will be scrapped')
+arg_engine.add_argument('-k', '--prefix', type=str, dest='prefix', default='page_', required=False, help='specifies prefix before every page, concatenated with number and format')
 arg_engine.add_argument('-f', '--force', dest='force', help='if given, overrides files in directory', **BOOL_PARAM)
 args = arg_engine.parse_args(list(argv[1:]))
 
@@ -23,13 +28,30 @@ bookId = args.book_id # book ID
 pages = args.pages # book page ccount
 datadir = Path(args.datadir) # path to directory with downloads
 override_files = args.force # override existing directory
+prefix = args.prefix
 # ----------------------------------
 
-opener = request.build_opener()
-opener.addheaders=[('User-Agent','Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1941.0 Safari/537.36')]
-request.install_opener(opener)
-pageText = "pages/page"
-fileExtension = ".PNG"
+def retrive_image(url, path):
+	"""save content received from given url to given path"""
+	response = get(url, headers=HEADERS)
+	with open(path, 'wb') as fhandle:
+		fhandle.write(response.content)
+
+def generate_url(page_num) -> str:
+	"""generates url for given page number"""
+	return f'{BASE_URL}{bookId}/pageNo:{page_num}'
+
+def generate_path(page_num) -> Path:
+	"""generates save path for given page number"""
+	return datadir / f'{prefix}{page_num}.{IMAGE_EXT}'
+
+def handle_page(page_num):
+	path = generate_path(page_num)
+	log.info(f'retriving page number {page_num} into: {path}')
+	url = generate_url(page_num)
+	log.info(f'downloading page number {page_num} from: {url}')
+	retrive_image(url, path)
+
 
 # Path handling
 if datadir.exists():
@@ -43,8 +65,4 @@ else:
 		log.error(f'exception occured while creating directory: {e}')
 
 for i in range (1,int(pages) + 1):
-  print("https://flipbook.apps.gwo.pl/book/getImage/bookId:" + str(bookId) + "/pageNo:" + str(i))
-  filename = pageText + str(i) + fileExtension
-  image_url = "https://flipbook.apps.gwo.pl/book/getImage/bookId:" + str(bookId) + "/pageNo:" + str(i)
-  request.urlretrieve(image_url, filename)
-  print("   " + filename)
+	handle_page(i)

--- a/script1.0.py
+++ b/script1.0.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 
-from requests import get
-from urllib import request
 from argparse import ArgumentParser
-from sys import argv
+from logging import INFO, basicConfig, getLogger
 from pathlib import Path
-from logging import INFO, getLogger, basicConfig
+from sys import argv
+from urllib.request import Request, urlopen
 
 # Logger configuration
 basicConfig(level=INFO, format='[%(levelname)s][%(asctime)s] %(message)s')
@@ -36,9 +35,9 @@ prefix = args.prefix
 
 def retrive_image(url, path):
 	"""save content received from given url to given path"""
-	response = get(url, headers=HEADERS)
+	response = urlopen(Request(url, headers=HEADERS, method='GET'))
 	with open(path, 'wb') as fhandle:
-		fhandle.write(response.content)
+		fhandle.write(response.read())
 
 def generate_url(page_num) -> str:
 	"""generates url for given page number"""


### PR DESCRIPTION
zmiany:

- dodano pobieranie wielowątkowe
- dodano generowanie PDF'ów (potencjalnie z błędem przy innych formatach niż A4)
- wydzielono opcje do linii poleceń
- dodano logowanie
- dodao `requirements.txt`, aby łatwiej było uruchomić skrypt

resolves #1 


dla ułatwienia, tutaj `./script1.0.py --help`

```
usage: script1.0.py [-h] -b BOOK_ID -p PAGES [-d DATADIR] [-k PREFIX] [-j JOBS] [-o PDF_NAME] [-f [FORCE]] [-v [VERB]] [--remove-unused [RM_UNUSED]]

options:
  -h, --help            show this help message and exit
  -b BOOK_ID, --book-id BOOK_ID
                        id of book to download
  -p PAGES, --pages PAGES
                        amount of pages to download
  -d DATADIR, --datadir DATADIR
                        specifies directory where pages will be scrapped
  -k PREFIX, --prefix PREFIX
                        specifies prefix before every page, concatenated with number and format
  -j JOBS, --jobs JOBS  specifies amount of jobs that will be used for downloading
  -o PDF_NAME, --out-pdf PDF_NAME
                        if specified, files will be squashed into one PDF with given name (overrides if exists!)
  -f [FORCE], --force [FORCE]
                        if given, overrides files in directory
  -v [VERB], --verbose [VERB]
                        if given, logs will be more descriptive
  --remove-unused [RM_UNUSED]
                        if given, with `-o` flag, removes all downloaded files
```

